### PR TITLE
Fix / render profiles from comments to be mentioned

### DIFF
--- a/lib/commons/common_text_field.dart
+++ b/lib/commons/common_text_field.dart
@@ -195,10 +195,8 @@ class _CommonTextFieldState extends State<CommonTextField> {
                               mentionTargetIds.add(mentionId);
                           });
                         }
-                        // TODO: POST /api/v1/posts/{postId}/comments 붙일 때 print문 삭제할 예정.
                         /// mentionTargetIds를 request에 담아 같이 보낼 예정.
-                        print(mentionTargetIds);
-                        key.currentState.controller.clear();
+                        // key.currentState.controller.clear();
                         mentionTargetIds.clear();
                       },
                       style: TextButton.styleFrom(

--- a/lib/providers/user_auth/authenticate.dart
+++ b/lib/providers/user_auth/authenticate.dart
@@ -66,7 +66,6 @@ class Authenticate with ChangeNotifier {
     } catch (e) {
       throw new Exception(e);
     }
-
     return idToken;
   }
 

--- a/lib/screens/boards/posts/detail/post_detail.dart
+++ b/lib/screens/boards/posts/detail/post_detail.dart
@@ -32,20 +32,13 @@ class _PostDetailState extends State<PostDetail> {
   final int maxRenderImgCnt = 4;
   bool commentImageExist = false;
   List<Map<String, dynamic>> mentionList = [];
-  List<Map<String, dynamic>> mentionList1 = [];
+  Set<int> mentionListId = {};
   List<Map<String, dynamic>> result = [];
 
   @override
   void initState() {
-    /// 게시글 작성자 프로필 추가 후 댓글 작성자 가운데 중복인 걸러내기 (Mention 위젯 입력 type은 Map<String, dynamic>)
     mentionList = [widget.post.profile.toJson()];
-    if (widget.post.comments != null)
-      widget.post.comments.forEach((e) => mentionList.add(e.profile.toJson()));
-    final jsonList = mentionList.map((e) => jsonEncode(e)).toList();
-    final uniqueJsonList = jsonList.toSet().toList();
-    mentionList = uniqueJsonList
-        .map((e) => jsonDecode(e) as Map<String, dynamic>).toList();
-
+    mentionListId = {widget.post.profile.id};
     super.initState();
   }
 
@@ -116,7 +109,7 @@ class _PostDetailState extends State<PostDetail> {
                   padding: EdgeInsets.only(top: 8, bottom: 20),
                   child: CustomDivider(color: GuamColorFamily.grayscaleGray7),
                 ),
-                // PostDetailBody(widget.post),
+                PostDetailBody(widget.post),
                 Padding(
                   padding: EdgeInsets.only(top: 14, bottom: 8),
                   child: PostInfo(
@@ -134,6 +127,15 @@ class _PostDetailState extends State<PostDetail> {
                     builder: (_, AsyncSnapshot snapshot) {
                       if (snapshot.hasData) {
                         if (snapshot.data.isNotEmpty) {
+                          // 댓글에서 중복을 허용하지 않도록 멘션 가능한 프로필 추출
+                          Future.delayed(
+                            Duration.zero,
+                            () => setState(() => snapshot.data.forEach((e) {
+                              if (!mentionListId.contains(e.profile.id))
+                                mentionList.add(e.profile.toJson());
+                              mentionListId.add(e.profile.id);
+                            }))
+                          );
                           return Column(
                             children: [
                               ...snapshot.data.map(
@@ -155,6 +157,7 @@ class _PostDetailState extends State<PostDetail> {
                         /// TODO: 에러 메시지 띄워주기
                         return Center(child: CircularProgressIndicator());
                       } else {
+                        /// API 통신 중...
                         return Center(child: CircularProgressIndicator());
                       }
                     }


### PR DESCRIPTION
> resolves #57 

- 지난 번 #56 의 후속 작업입니다.

- Comments API에서 프로필을 중복을 허용하지 않게 추출하여 멘션 시 id 값을 리스트에 저장하여 POST posts/{postId}/comments의 body로 추가하기 위한 사전 작업입니다.