### PR TITLE
Fix / 익명게시판

### DIFF
--- a/lib/models/boards/comment.dart
+++ b/lib/models/boards/comment.dart
@@ -7,6 +7,7 @@ class Comment extends ChangeNotifier {
   final int postId;
   final Profile profile;
   final String content;
+  final bool isMine;
   final bool isLiked;
   final List<dynamic> imagePaths; /// 임시 방편 (추후 pictures 활용 예정)
   final int likeCount;
@@ -17,6 +18,7 @@ class Comment extends ChangeNotifier {
     this.postId,
     this.profile,
     this.content,
+    this.isMine,
     this.isLiked,
     this.imagePaths,
     this.likeCount,
@@ -35,6 +37,7 @@ class Comment extends ChangeNotifier {
       postId: json['postId'],
       profile: profile,
       content: json['content'],
+      isMine: json['isMine'],
       isLiked: json['isLiked'],
       imagePaths: json['imagePaths'],
       likeCount: json['likeCount'],

--- a/lib/models/boards/post.dart
+++ b/lib/models/boards/post.dart
@@ -17,6 +17,7 @@ class Post extends ChangeNotifier {
   final int likeCount;
   final int commentCount;
   final int scrapCount;
+  final bool isMine;
   final bool isLiked;
   final bool isScrapped;
   final String createdAt;
@@ -33,6 +34,7 @@ class Post extends ChangeNotifier {
     this.likeCount,
     this.commentCount,
     this.scrapCount,
+    this.isMine,
     this.isLiked,
     this.isScrapped,
     this.createdAt,
@@ -96,6 +98,7 @@ class Post extends ChangeNotifier {
       likeCount: json['likeCount'],
       commentCount: json['commentCount'],
       scrapCount: json['scrapCount'],
+      isMine: json['isMine'],
       isLiked: json['isLiked'],
       isScrapped: json['isScrapped'],
       createdAt: json['createdAt'],

--- a/lib/screens/boards/comments/comment_banner.dart
+++ b/lib/screens/boards/comments/comment_banner.dart
@@ -25,7 +25,8 @@ class CommentBanner extends StatelessWidget {
             nickname: comment.profile.nickname,
             nicknameColor: GuamColorFamily.grayscaleGray3,
           ),
-          if (isAuthor)
+          if (isAuthor && comment.profile.id != 0) 
+            /// 익명게시판의 경우 id가 모두 0인 것을 이용해 익명게시글 내 댓글에서 '작성자' 표시는 항상 안보이게 만듦.
             Container(
               margin: EdgeInsets.only(left: 4),
               padding: EdgeInsets.symmetric(vertical: 2, horizontal: 8),

--- a/lib/screens/boards/comments/comment_more.dart
+++ b/lib/screens/boards/comments/comment_more.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:guam_community_client/models/boards/comment.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
-import 'package:provider/provider.dart';
 
 import '../../../commons/bottom_modal/bottom_modal_default.dart';
 import '../../../commons/bottom_modal/bottom_modal_with_alert.dart';
 import '../../../commons/bottom_modal/bottom_modal_with_message.dart';
-import '../../../models/profiles/profile.dart';
-import '../../../providers/user_auth/authenticate.dart';
 import '../posts/post_comment_report.dart';
 
 class CommentMore extends StatelessWidget {
@@ -17,14 +14,12 @@ class CommentMore extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Profile myProfile = context.read<Authenticate>().me;
-
     return SingleChildScrollView(
       child: Container(
         padding: EdgeInsets.only(left: 24, top: 24, bottom: 21),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: comment.profile.id == myProfile.id ? [
+          children: comment.isMine ? [
             BottomModalDefault(
               text: '수정하기',
               onPressed: () {

--- a/lib/screens/boards/posts/detail/post_detail_more.dart
+++ b/lib/screens/boards/posts/detail/post_detail_more.dart
@@ -6,9 +6,7 @@ import '../../../../commons/bottom_modal/bottom_modal_default.dart';
 import '../../../../commons/bottom_modal/bottom_modal_with_alert.dart';
 import '../../../../commons/bottom_modal/bottom_modal_with_message.dart';
 import '../../../../models/boards/post.dart';
-import '../../../../models/profiles/profile.dart';
 import '../../../../providers/posts/posts.dart';
-import '../../../../providers/user_auth/authenticate.dart';
 import '../creation/post_creation.dart';
 import '../post_comment_report.dart';
 
@@ -19,14 +17,12 @@ class PostDetailMore extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Profile myProfile = context.read<Authenticate>().me;
-
     return SingleChildScrollView(
       child: Container(
         padding: EdgeInsets.only(left: 24, top: 24, bottom: 21),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: post.profile.id == myProfile.id ? [
+          children: post.isMine ? [
             BottomModalDefault(
               text: '수정하기',
               onPressed: () => Navigator.of(context).push(


### PR DESCRIPTION
> resolves #72 

- [x] 익명게시글의 댓글에서 작성자임을 확인할 수 있는 '**작성자**' badge 떼기
  > 익명글에서는 user id가 항상 0임을 이용하여 if 문 수정

- [x] 익명게시글 내 **more** 버튼 로직 수정
  > 기존 auth에서 들고 있는 id와 글/댓글 작성자 id를 비교하는 방식을 탈피하고, 서버에서 항상 isMine boolean을 내려주는 방식으로 바뀜.