### PR TITLE
Fix /  getUserProfile 로직 수정

### DIFF
--- a/lib/screens/profiles/profiles_app.dart
+++ b/lib/screens/profiles/profiles_app.dart
@@ -42,10 +42,11 @@ class _ProfilesAppScaffoldState extends State<ProfilesAppScaffold> {
   @override
   void initState() {
     super.initState();
-    otherProfile = Future.delayed(
-      Duration.zero,
-      () async => context.read<Authenticate>().getUserProfile(widget.userId),
-    );
+    if (widget.userId != null)
+      otherProfile = Future.delayed(
+        Duration.zero,
+        () async => context.read<Authenticate>().getUserProfile(widget.userId),
+      );
   }
 
   @override


### PR DESCRIPTION
### DEBUG : users/null을 클라이언트(모바일)에서 계속 호출하던 에러 수정.

- 원인 : 앱 시작 시 모바일 프로필 탭을 렌더링하는 과정에서 다른 사람의 프로필을 열람하는 기능이 불필요하게 호출
> 타인 프로필 및 나의 프로필을 위한 위젯을 공유하는 부분에서 내 프로필을 볼 때, 부모로부터 넘어오는 userId가 null(왜냐하면 users/me API를 쓰기 때문에 user/{userId}를 쓸 필요가 없어서 null로 넘기도록 설계함)인 경우에도 provider의 getUserProfile이 수행되었음. (users/{userId} API 사용함)

- 해결방법 : 부모로부터 넘어오는 userId가 null인 경우, getUserProfile 함수를 수행하지 않도록 분기 설정

- [슬랙 논의 참고](https://wafflestudio.slack.com/archives/C02BEPGJW9Y/p1649487856306419)