### PR TITLE
Fix / posts (toast, bottomModal)

### DIFF
--- a/lib/commons/functions_category_boardType.dart
+++ b/lib/commons/functions_category_boardType.dart
@@ -27,6 +27,18 @@ transferBoardType(String boardType) {
   return boardId;
 }
 
+transferCategoryId(int categoryId) {
+  String category;
+  switch (categoryId) {
+    case 1: category = '개발'; break;
+    case 2: category = '데이터분석'; break;
+    case 3: category = '디자인'; break;
+    case 4: category = '기획/마케팅'; break;
+    case 5: category = '기타'; break;
+  }
+  return category;
+}
+
 transferCategory(String category) {
   int categoryId;
   switch (category) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:bot_toast/bot_toast.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:guam_community_client/screens/app/splash/splash_screen.dart';
@@ -46,11 +47,12 @@ class MyApp extends StatelessWidget {
               ChangeNotifierProvider<Authenticate>(create: (_) => Authenticate()),
             ],
             child: MaterialApp(
-              debugShowCheckedModeBanner: false,
               initialRoute: '/',
               routes: {
                 '/': (context) => Auth(),
               },
+              builder: BotToastInit(),
+              debugShowCheckedModeBanner: false,
               theme: ThemeData(
                 primaryColor: GuamColorFamily.purpleCore,
                 fontFamily: GuamFontFamily.SpoqaHanSansNeoMedium,

--- a/lib/models/boards/category.dart
+++ b/lib/models/boards/category.dart
@@ -1,7 +1,8 @@
+/// category.title 은 게시글 수정 시 non-final 로 정의
 class Category {
   final int postId;
   final int categoryId;
-  final String title;
+  String title;
 
   Category({this.postId, this.categoryId, this.title});
 

--- a/lib/models/boards/post.dart
+++ b/lib/models/boards/post.dart
@@ -5,13 +5,14 @@ import 'package:guam_community_client/models/boards/category.dart' as Category;
 import 'package:guam_community_client/models/boards/comment.dart';
 import '../profiles/profile.dart';
 
+/// title, content, boardType, category는 게시글 수정 시 non-final로 정의
 class Post extends ChangeNotifier {
   final int id;
-  final String boardType; // ex) 익명, 홍보, 정보공유 게시판
+  String boardType; // ex) 익명, 홍보, 정보공유 게시판
   final Profile profile;
-  final String title;
-  final String content;
-  final Category.Category category; // ex) 데이터분석, 개발, 디자인
+  String title;
+  String content;
+  Category.Category category; // ex) 데이터분석, 개발, 디자인
   final List<dynamic> imagePaths; // 서버 수정 전까지 쓰이는 임시방편 속성
   final List<Comment> comments;
   final int likeCount;

--- a/lib/providers/posts/posts.dart
+++ b/lib/providers/posts/posts.dart
@@ -240,14 +240,15 @@ class Posts extends ChangeNotifier with Toast {
         ).then((response) {
           print(response.statusCode);
           if (response.statusCode == 200) {
-            final jsonUtf8 = decodeKo(response);
-            final String msg = json.decode(jsonUtf8)["message"];
-            // showToast(success: true, msg: msg);
+            showToast(success: true, msg: '게시글을 삭제했습니다.');
             successful = true;
           } else {
-            final jsonUtf8 = decodeKo(response);
-            final String err = json.decode(jsonUtf8)["message"];
-            // showToast(success: false, msg: err);
+            String msg = '알 수 없는 오류가 발생했습니다.';
+            switch (response.statusCode) {
+              case 401: msg = '삭제 권한이 없습니다.'; break;
+              case 404: msg = '존재하지 않는 게시글입니다.'; break;
+            }
+            showToast(success: false, msg: msg);
           }
         });
         loading = false;

--- a/lib/providers/posts/posts.dart
+++ b/lib/providers/posts/posts.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:guam_community_client/mixins/toast.dart';
 import 'package:guam_community_client/providers/search/search.dart';
 import 'package:flutter/foundation.dart';
 import 'package:guam_community_client/models/boards/comment.dart';
@@ -10,7 +11,7 @@ import '../../models/boards/post.dart';
 import '../../models/filter.dart';
 import '../user_auth/authenticate.dart';
 
-class Posts with ChangeNotifier {
+class Posts extends ChangeNotifier with Toast {
   Authenticate _authProvider;
   Post _post;
   bool _hasNext;
@@ -50,8 +51,13 @@ class Posts with ChangeNotifier {
           sortSearchedPosts(Search.filters.first);
           loading = false;
         } else {
-          final jsonUtf8 = decodeKo(response);
-          final String err = json.decode(jsonUtf8)["message"];
+          String msg = '알 수 없는 오류가 발생했습니다.';
+          switch (response.statusCode) {
+            case 400: msg = '정보를 모두 입력해주세요.'; break;
+            case 401: msg = '열람 권한이 없습니다.'; break;
+            case 404: msg = '존재하지 않는 게시판입니다.'; break;
+          }
+          showToast(success: false, msg: msg);
         }
       });
       loading = false;
@@ -120,14 +126,15 @@ class Posts with ChangeNotifier {
           if (response.statusCode == 200) {
             successful = true;
             loading = false;
-            final jsonUtf8 = decodeKo(response);
-            // final String msg = json.decode(jsonUtf8)["message"];
-            // showToast(success: true, msg: msg);
+            showToast(success: true, msg: '게시글을 작성했습니다.');
           } else {
-            final jsonUtf8 = decodeKo(response);
-            // final String err = json.decode(jsonUtf8)["message"];
-            // TODO: show toast after impl. toast
-            // showToast(success: false, msg: err);
+            String msg = '알 수 없는 오류가 발생했습니다.';
+            switch (response.statusCode) {
+              case 400: msg = '정보를 모두 입력해주세요.'; break;
+              case 401: msg = '글쓰기 권한이 없습니다.'; break;
+              case 404: msg = '정보를 모두 입력해주세요.'; break;
+            }
+            showToast(success: false, msg: msg);
           }
         });
         loading = false;
@@ -157,9 +164,14 @@ class Posts with ChangeNotifier {
             final Map<String, dynamic> jsonData = json.decode(jsonUtf8);
             _post = Post.fromJson(jsonData);
           } else {
-            final jsonUtf8 = decodeKo(response);
-            final String err = json.decode(jsonUtf8)["message"];
-            // showToast(success: false, msg: err);
+            // final jsonUtf8 = decodeKo(response);
+            // final String err = json.decode(jsonUtf8)["message"];
+            String msg = '알 수 없는 오류가 발생했습니다.';
+            switch (response.statusCode) {
+              case 401: msg = '접근 권한이 없습니다.'; break;
+              case 404: msg = '존재하지 않는 게시글입니다.'; break;
+            }
+            showToast(success: false, msg: msg);
           }
         });
       }
@@ -191,18 +203,16 @@ class Posts with ChangeNotifier {
             loading = false;
             final jsonUtf8 = decodeKo(response);
             final Map<String, dynamic> jsonData = json.decode(jsonUtf8);
-
-            /// todo: Server 측에서 response 수정해주면 getPost API 안날리고 아래 line으로 해결 가능.
             await getPost(jsonData['postId']);
-            // _post = Post.fromJson(jsonData);
-
-            // final String msg = json.decode(jsonUtf8)["message"];
-            // showToast(success: true, msg: msg);
+            showToast(success: true, msg: '게시글을 수정했습니다.');
           } else {
-            final jsonUtf8 = decodeKo(response);
-            // final String err = json.decode(jsonUtf8)["message"];
-            // TODO: show toast after impl. toast
-            // showToast(success: false, msg: err);
+            String msg = '알 수 없는 오류가 발생했습니다.';
+            switch (response.statusCode) {
+              case 400: msg = '정보를 모두 입력해주세요.'; break;
+              case 401: msg = '수정 권한이 없습니다.'; break;
+              case 404: msg = '정보를 모두 입력해주세요.'; break;
+            }
+            showToast(success: false, msg: msg);
           }
         });
         loading = false;

--- a/lib/screens/boards/posts/creation/post_creation_category.dart
+++ b/lib/screens/boards/posts/creation/post_creation_category.dart
@@ -29,7 +29,11 @@ class _PostCreationCategoryState extends State<PostCreationCategory> {
   }
 
   void initCategory(){
-    setState(() => widget.input['category'] = '');
+    setState(() {
+      widget.input['category'] = '';
+      widget.input['categoryId'] = 0;
+    });
+    print(widget.input);
   }
 
   @override

--- a/lib/screens/boards/posts/detail/post_detail.dart
+++ b/lib/screens/boards/posts/detail/post_detail.dart
@@ -86,7 +86,10 @@ class _PostDetailState extends State<PostDetail> {
                 IconButton(
                   padding: EdgeInsets.symmetric(vertical: 10, horizontal: 10),
                   constraints: BoxConstraints(),
-                  icon: SvgPicture.asset('assets/icons/scrap_outlined.svg'),
+                  icon: SvgPicture.asset(widget.post.isScrapped
+                      ? 'assets/icons/scrap_filled.svg'
+                      : 'assets/icons/scrap_outlined.svg'
+                  ),
                   onPressed: () {},
                 ),
                 IconButton(

--- a/lib/screens/boards/posts/detail/post_detail.dart
+++ b/lib/screens/boards/posts/detail/post_detail.dart
@@ -14,7 +14,6 @@ import 'package:guam_community_client/screens/boards/posts/detail/post_detail_bo
 import 'package:guam_community_client/screens/boards/posts/detail/post_detail_more.dart';
 import 'package:guam_community_client/screens/boards/posts/post_info.dart';
 import 'package:guam_community_client/styles/colors.dart';
-import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../commons/functions_category_boardType.dart';
@@ -49,6 +48,7 @@ class _PostDetailState extends State<PostDetail> {
   /// 게시글 수정 시, API의 request는 Client가 들고있다는 원칙 및 서버 통신 성공 가정 하에
   /// 수정 버튼 클릭하면 사용자에게 수정 내용 바로 반영되도록 만듦.
   getEditedPost(Map editedPost) {
+    if (editedPost == null) return;
     int editedBoardId = int.parse(editedPost['boardId']);
     int editedCategoryId = int.parse(editedPost['categoryId']);
 
@@ -121,7 +121,7 @@ class _PostDetailState extends State<PostDetail> {
                   padding: EdgeInsets.zero,
                   constraints: BoxConstraints(),
                   icon: SvgPicture.asset('assets/icons/more.svg'),
-                  onPressed: () => showCupertinoModalBottomSheet(
+                  onPressed: () => showModalBottomSheet(
                     /// DetailMore에서 Detail로 수정된 게시글 정보 넘기기
                     context: context,
                     useRootNavigator: true,

--- a/lib/screens/boards/posts/detail/post_detail_more.dart
+++ b/lib/screens/boards/posts/detail/post_detail_more.dart
@@ -7,17 +7,29 @@ import '../../../../commons/bottom_modal/bottom_modal_with_alert.dart';
 import '../../../../commons/bottom_modal/bottom_modal_with_message.dart';
 import '../../../../models/boards/post.dart';
 import '../../../../providers/posts/posts.dart';
-import '../../../../providers/user_auth/authenticate.dart';
 import '../creation/post_creation.dart';
 import '../post_comment_report.dart';
 
 class PostDetailMore extends StatelessWidget {
   final Post post;
+  final Function getEditedPost;
 
-  PostDetailMore(this.post);
+  PostDetailMore(this.post, this.getEditedPost);
 
   @override
   Widget build(BuildContext context) {
+    _navigatePage(BuildContext context) async {
+      final result = await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => ChangeNotifierProvider.value(
+            value: context.read<Posts>(),
+            child: PostCreation(isEdit: true, editTarget: post),
+          ),
+        ),
+      );
+      getEditedPost(result);
+    }
     return SingleChildScrollView(
       child: Container(
         padding: EdgeInsets.only(left: 24, top: 24, bottom: 21),
@@ -26,18 +38,7 @@ class PostDetailMore extends StatelessWidget {
           children: post.isMine ? [
             BottomModalDefault(
               text: '수정하기',
-              /// Navigator 사용 시 Provider가 정의된 route가 달라져 새롭게 정의해야함.
-              onPressed: () => Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => ChangeNotifierProvider(
-                    create: (context) => Posts(context.read<Authenticate>()),
-                    child: PostCreation(
-                      isEdit: true,
-                      editTarget: post, // 수정할 대상 (Post)
-                    ),
-                  ),
-                ),
-              ),
+              onPressed: () => _navigatePage(context),
             ),
             BottomModalWithAlert(
               funcName: '삭제하기',

--- a/lib/screens/boards/posts/post_button.dart
+++ b/lib/screens/boards/posts/post_button.dart
@@ -23,17 +23,15 @@ class PostButton extends StatelessWidget {
               width: 30,
               height: 30,
             ),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => ChangeNotifierProvider.value(
-                    value: context.read<Posts>(),
-                    child: PostCreation(),
-                  )
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => ChangeNotifierProvider.value(
+                  value: context.read<Posts>(),
+                  child: PostCreation(),
                 )
-              );
-            }
+              )
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
> resolves #88 

- [x] toast 메시지 표출 (게시글 작성/수정/삭제)

- [x] 게시글 수정 로직 (Server에서 수정된 게시글 정보를 주지 않기 때문에 request를 들고 있는 Client 단에서 반영)
  > 관련하여 Model에 final을 detach하는 케이스 생김(title, content, category, boardType)

- [x] Navigator.pop 함수의 두 번째 인자를 사용하여 BottomModal 왔다갔다 할 때도 context 유지

