### PR TITLE
Api / like and scrap

### DIFF
--- a/lib/models/boards/post.dart
+++ b/lib/models/boards/post.dart
@@ -8,6 +8,7 @@ import '../profiles/profile.dart';
 /// title, content, boardType, category는 게시글 수정 시 non-final로 정의
 class Post extends ChangeNotifier {
   final int id;
+  final int boardId;
   String boardType; // ex) 익명, 홍보, 정보공유 게시판
   final Profile profile;
   String title;
@@ -26,6 +27,7 @@ class Post extends ChangeNotifier {
   Post({
     this.id,
     this.profile,
+    this.boardId,
     this.boardType,
     this.title,
     this.content,
@@ -82,10 +84,7 @@ class Post extends ChangeNotifier {
     return Post(
       id: json['id'],
       profile: profile,
-      /**
-       * Server에서 boardType 대신 boardId로 주고 있어 함수(transferBoardId)를 통해
-       * int -> str 번역하고 있는데, 추후 str (ex. 익명게시판)으로 받아오면 해당 함수 없애기
-       **/
+      boardId: json['boardId'],
       boardType: transferBoardId(json['boardId']),
       title: json['title'],
       content: json['content'],

--- a/lib/providers/posts/posts.dart
+++ b/lib/providers/posts/posts.dart
@@ -395,7 +395,7 @@ class Posts extends ChangeNotifier with Toast {
     return successful;
   }
 
-  Future unlikePost({int postId}) async {
+  Future<bool> unlikePost({int postId}) async {
     loading = true;
     bool successful = false;
     try {
@@ -415,6 +415,74 @@ class Posts extends ChangeNotifier with Toast {
               case 401: msg = "권한이 없습니다."; break;
               case 404: msg = "존재하지 않는 게시글입니다."; break;
               case 409: msg = "이미 '좋아요' 취소한 글입니다."; break;
+            }
+            showToast(success: false, msg: msg);
+          }
+        });
+        loading = false;
+      }
+    } catch (e) {
+      print(e);
+    } finally {
+      notifyListeners();
+    }
+    return successful;
+  }
+
+  Future<bool> scrapPost({int postId}) async {
+    loading = true;
+    bool successful = false;
+    try {
+      String authToken = await _authProvider.getFirebaseIdToken();
+      if (authToken.isNotEmpty) {
+        await HttpRequest()
+            .post(
+          path: "community/api/v1/posts/$postId/scraps",
+          authToken: authToken,
+        ).then((response) async {
+          if (response.statusCode == 200) {
+            loading = false;
+            successful = true;
+          } else {
+            String msg = "알 수 없는 오류가 발생했습니다.";
+            switch (response.statusCode) {
+              case 401: msg = "권한이 없습니다."; break;
+              case 404: msg = "존재하지 않는 게시글입니다."; break;
+              case 409: msg = "이미 스크랩한 글입니다."; break;
+            }
+            showToast(success: false, msg: msg);
+          }
+        });
+        loading = false;
+      }
+    } catch (e) {
+      print(e);
+    } finally {
+      notifyListeners();
+    }
+    return successful;
+  }
+
+  Future<bool> unscrapPost({int postId}) async {
+    loading = true;
+    bool successful = false;
+    try {
+      String authToken = await _authProvider.getFirebaseIdToken();
+      if (authToken.isNotEmpty) {
+        await HttpRequest()
+            .delete(
+          path: "community/api/v1/posts/$postId/scraps",
+          authToken: authToken,
+        ).then((response) async {
+          if (response.statusCode == 200) {
+            loading = false;
+            successful = true;
+          } else {
+            String msg = "알 수 없는 오류가 발생했습니다.";
+            switch (response.statusCode) {
+              case 401: msg = "권한이 없습니다."; break;
+              case 404: msg = "존재하지 않는 게시글입니다."; break;
+              case 409: msg = "이미 스크랩 취소한 글입니다."; break;
             }
             showToast(success: false, msg: msg);
           }

--- a/lib/screens/boards/posts/creation/post_creation_category.dart
+++ b/lib/screens/boards/posts/creation/post_creation_category.dart
@@ -33,7 +33,6 @@ class _PostCreationCategoryState extends State<PostCreationCategory> {
       widget.input['category'] = '';
       widget.input['categoryId'] = 0;
     });
-    print(widget.input);
   }
 
   @override

--- a/lib/screens/boards/posts/post_info.dart
+++ b/lib/screens/boards/posts/post_info.dart
@@ -3,9 +3,12 @@ import 'package:guam_community_client/commons/icon_text.dart';
 import 'package:guam_community_client/models/boards/post.dart';
 import 'package:guam_community_client/styles/colors.dart';
 import 'package:hexcolor/hexcolor.dart';
-import '../../../commons/common_img_nickname.dart';
+import 'package:provider/provider.dart';
 
-class PostInfo extends StatelessWidget {
+import '../../../commons/common_img_nickname.dart';
+import '../../../providers/posts/posts.dart';
+
+class PostInfo extends StatefulWidget {
   final Post post;
   final double iconSize;
   final bool showProfile;
@@ -21,51 +24,110 @@ class PostInfo extends StatelessWidget {
   });
 
   @override
+  State<PostInfo> createState() => _PostInfoState();
+}
+
+class _PostInfoState extends State<PostInfo> {
+  bool isLiked;
+  bool isScrapped;
+  int likeCount;
+  int scrapCount;
+
+  @override
+  void initState() {
+    isLiked = widget.post.isLiked;
+    isScrapped = widget.post.isScrapped;
+    likeCount = widget.post.likeCount;
+    scrapCount = widget.post.scrapCount;
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final postsProvider = context.watch<Posts>();
+
+    Future likeOrUnlikePost() async {
+      try {
+        if (!isLiked) {
+          return await postsProvider.likePost(
+            postId: widget.post.id,
+          ).then((successful) {
+            if (successful) {
+              setState(() {
+                isLiked = true;
+                likeCount ++;
+              });
+              successful = true;
+            } else {
+              print(postsProvider.boardId);
+              return postsProvider.fetchPosts(postsProvider.boardId);
+            }
+          });
+        } else {
+          return await postsProvider.unlikePost(
+            postId: widget.post.id,
+          ).then((successful) {
+            if (successful) {
+              setState(() {
+                isLiked = !isLiked;
+                likeCount --;
+              });
+              successful = true;
+            } else {
+              print(postsProvider.boardId);
+              return postsProvider.fetchPosts(postsProvider.boardId);
+            }
+          });
+        }
+      } catch (e) {
+        print(e);
+      }
+    }
+
     return Padding(
       padding: EdgeInsets.only(top: 8, bottom: 12),
       child: Row(
         children: [
-          if (showProfile)
+          if (widget.showProfile)
             CommonImgNickname(
-              imgUrl: post.profile.profileImg,
-              nickname: post.profile.nickname,
-              profileClickable: profileClickable,
+              imgUrl: widget.post.profile.profileImg,
+              nickname: widget.post.profile.nickname,
+              profileClickable: widget.profileClickable,
               nicknameColor: GuamColorFamily.grayscaleGray2,
             ),
-          if (showProfile) Spacer(),
+          if (widget.showProfile) Spacer(),
           Row(
             children: [
               IconText(
-                iconSize: iconSize,
-                text: post.likeCount.toString(),
-                iconPath: post.isLiked ?? false  /// 서버 수정 후 ?? false 삭제
+                iconSize: widget.iconSize,
+                text: likeCount.toString(),
+                iconPath: isLiked
                     ? 'assets/icons/like_filled.svg'
                     : 'assets/icons/like_outlined.svg',
-                onPressed: (){},
-                iconColor: post.isLiked ?? false  /// 서버 수정 후 ?? false 삭제
+                onPressed: likeOrUnlikePost,
+                iconColor: isLiked
                     ? GuamColorFamily.redCore
-                    : iconColor,
-                textColor: iconColor,
+                    : widget.iconColor,
+                textColor: widget.iconColor,
               ),
               IconText(
-                iconSize: iconSize,
-                text: post.commentCount.toString(),
+                iconSize: widget.iconSize,
+                text: widget.post.commentCount.toString(),
                 iconPath: 'assets/icons/comment.svg',
-                iconColor: iconColor,
-                textColor: iconColor,
+                iconColor: widget.iconColor,
+                textColor: widget.iconColor,
               ),
               IconText(
-                iconSize: iconSize,
-                text: post.scrapCount.toString(),
-                iconPath: post.isScrapped ?? false  /// 서버 수정 후 ?? false 삭제
+                iconSize: widget.iconSize,
+                text: widget.post.scrapCount.toString(),
+                iconPath: widget.post.isScrapped
                     ? 'assets/icons/scrap_filled.svg'
                     : 'assets/icons/scrap_outlined.svg',
-                onPressed: (){},
-                iconColor: post.isScrapped ?? false  /// 서버 수정 후 ?? false 삭제
+                onPressed: () {},
+                iconColor: widget.post.isScrapped
                     ? GuamColorFamily.purpleCore
-                    : iconColor,
-                textColor: iconColor,
+                    : widget.iconColor,
+                textColor: widget.iconColor,
               ),
             ],
           ),

--- a/lib/screens/boards/posts/post_info.dart
+++ b/lib/screens/boards/posts/post_info.dart
@@ -84,6 +84,42 @@ class _PostInfoState extends State<PostInfo> {
       }
     }
 
+    Future scrapOrUnscrapPost() async {
+      try {
+        if (!isScrapped) {
+          return await postsProvider.scrapPost(
+            postId: widget.post.id,
+          ).then((successful) {
+            if (successful) {
+              setState(() {
+                isScrapped = true;
+                scrapCount ++;
+              });
+              successful = true;
+            } else {
+              return postsProvider.fetchPosts(postsProvider.boardId);
+            }
+          });
+        } else {
+          return await postsProvider.unscrapPost(
+            postId: widget.post.id,
+          ).then((successful) {
+            if (successful) {
+              setState(() {
+                isScrapped = !isScrapped;
+                scrapCount --;
+              });
+              successful = true;
+            } else {
+              return postsProvider.fetchPosts(postsProvider.boardId);
+            }
+          });
+        }
+      } catch (e) {
+        print(e);
+      }
+    }
+
     return Padding(
       padding: EdgeInsets.only(top: 8, bottom: 12),
       child: Row(
@@ -119,12 +155,12 @@ class _PostInfoState extends State<PostInfo> {
               ),
               IconText(
                 iconSize: widget.iconSize,
-                text: widget.post.scrapCount.toString(),
-                iconPath: widget.post.isScrapped
+                text: scrapCount.toString(),
+                iconPath: isScrapped
                     ? 'assets/icons/scrap_filled.svg'
                     : 'assets/icons/scrap_outlined.svg',
-                onPressed: () {},
-                iconColor: widget.post.isScrapped
+                onPressed: scrapOrUnscrapPost,
+                iconColor: isScrapped
                     ? GuamColorFamily.purpleCore
                     : widget.iconColor,
                 textColor: widget.iconColor,


### PR DESCRIPTION
> resolves #85 

## What I've Done

- [x] 세부 게시글 열람 시, GET posts response 대신 새롭게 GET posts/postId 사용
  > 이유 : 게시글 프리뷰에서 좋아요/스크랩 시 게시글 내부에서도 반영해주기 위해.

- [x] 게시글 좋아요/좋아요 취소 API

- [x] 게시글 스크랩/스크랩 취소 API

---

### 참고
- 게시글 내부에서 좋아요/스크랩 후, 뒤로 나가면 아직 반영이 되어 있지 않음. (반영하려면 게시글 목록 페이지를 매번 새로고침해야 하는데, UX상 옳지 않음. 따라서 **"굳이", "바로"** 반영되어 있지 않은 게시글을 좋아요/스크랩하는 경우, 에러메시지와 함께 새로고침하도록 수정함.

