### PR TITLE
Api / comment delete

### DIFF
--- a/lib/providers/posts/posts.dart
+++ b/lib/providers/posts/posts.dart
@@ -309,11 +309,15 @@ class Posts extends ChangeNotifier with Toast {
           if (response.statusCode == 200) {
             successful = true;
             loading = false;
+            showToast(success: true, msg: '댓글을 작성했습니다.');
           } else {
-            final jsonUtf8 = decodeKo(response);
-            // final String err = json.decode(jsonUtf8)["error"];
-            // TODO: show toast after impl. toast
-            // showToast(success: false, msg: err);
+            String msg = "알 수 없는 오류가 발생했습니다.";
+            switch (response.statusCode) {
+              case 400: msg = "빈 댓글은 입력할 수 없습니다."; break;
+              case 401: msg = "권한이 없습니다."; break;
+              case 404: msg = "존재하지 않는 글입니다."; break;
+            }
+            showToast(success: false, msg: msg);
           }
         });
         loading = false;
@@ -338,17 +342,19 @@ class Posts extends ChangeNotifier with Toast {
             .delete(
           path: "community/api/v1/posts/$postId/comments/$commentId",
           authToken: authToken,
-        ).then((response) {
-          print(response.statusCode);
+        ).then((response) async {
           if (response.statusCode == 200) {
-            final jsonUtf8 = decodeKo(response);
-            final String msg = json.decode(jsonUtf8)["message"];
-            // showToast(success: true, msg: msg);
+            fetchComments(postId);
+            showToast(success: true, msg: '댓글을 삭제했습니다.');
             successful = true;
           } else {
-            final jsonUtf8 = decodeKo(response);
-            final String err = json.decode(jsonUtf8)["message"];
-            // showToast(success: false, msg: err);
+            String msg = "알 수 없는 오류가 발생했습니다.";
+            switch (response.statusCode) {
+              case 401: msg = "권한이 없습니다."; break;
+              case 404: msg = "존재하지 않는 댓글입니다."; break;
+              case 409: msg = "이미 삭제된 댓글입니다."; break;
+            }
+            showToast(success: false, msg: msg);
           }
         });
         loading = false;

--- a/lib/screens/boards/comments/comment_banner.dart
+++ b/lib/screens/boards/comments/comment_banner.dart
@@ -10,8 +10,9 @@ import '../../../styles/fonts.dart';
 class CommentBanner extends StatelessWidget {
   final Comment comment;
   final bool isAuthor;
+  final Function deleteFunc;
 
-  CommentBanner(this.comment, this.isAuthor);
+  CommentBanner(this.comment, this.isAuthor, this.deleteFunc);
 
   @override
   Widget build(BuildContext context) {
@@ -63,7 +64,7 @@ class CommentBanner extends StatelessWidget {
                   topRight: Radius.circular(20),
                 )
               ),
-              builder: (context) => CommentMore(comment),
+              builder: (context) => CommentMore(comment, deleteFunc),
             ),
           ),
         ],

--- a/lib/screens/boards/comments/comment_more.dart
+++ b/lib/screens/boards/comments/comment_more.dart
@@ -7,79 +7,91 @@ import '../../../commons/bottom_modal/bottom_modal_default.dart';
 import '../../../commons/bottom_modal/bottom_modal_with_alert.dart';
 import '../../../commons/bottom_modal/bottom_modal_with_message.dart';
 import '../../../providers/posts/posts.dart';
+import '../../../providers/user_auth/authenticate.dart';
 import '../posts/post_comment_report.dart';
 
 class CommentMore extends StatelessWidget {
   final Comment comment;
+  final Function deleteFunc;
 
-  const CommentMore(this.comment);
+  const CommentMore(this.comment, this.deleteFunc);
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      child: Container(
-        padding: EdgeInsets.only(left: 24, top: 24, bottom: 21),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: comment.isMine ? [
-            BottomModalDefault(
-              text: '수정하기',
-              onPressed: () {
-                Navigator.pop(context);
-              },
-            ),
-            BottomModalWithAlert(
-              funcName: '삭제하기',
-              title: '댓글을 삭제하시겠어요?',
-              body: '삭제된 댓글은 복원할 수 없습니다.',
-              /// todo: PR 분리하여 이슈 해결할 예정
-              // func: () async {
-              //   await context.read<Posts>().deleteComment(
-              //     postId: comment.postId, commentId: comment.id,
-              //   ).then((successful) {
-              //     if (successful) {
-              //       Navigator.of(context).pop();
-              //       Navigator.of(context).pop();
-              //       // Navigator.of(context).pushNamedAndRemoveUntil(
-              //       //     '/', (route) => true
-              //       // );
-              //     }
-              //   });
-              // },
-            ),
-          ] : [
-            BottomModalDefault(
-              text: '쪽지 보내기',
-              onPressed: () => showMaterialModalBottomSheet(
-                context: context,
-                useRootNavigator: true,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.only(
-                    topLeft: Radius.circular(20),
-                    topRight: Radius.circular(20),
-                  ),
-                ),
-                builder: (context) => Container(
-                  child: SingleChildScrollView(
-                    child: BottomModalWithMessage(
-                      funcName: '보내기',
-                      title: '${comment.profile.nickname} 님에게 쪽지 보내기',
-                      profile: comment.profile,
-                      func: null,
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => Posts(context.watch<Authenticate>())),
+      ],
+      child: Builder(
+        builder: (context) {
+          Posts postsProvider = context.read<Posts>();
+
+          return ChangeNotifierProvider.value(
+            value: postsProvider,
+            child: SingleChildScrollView(
+              child: Container(
+                padding: EdgeInsets.only(left: 24, top: 24, bottom: 21),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: comment.isMine ? [
+                    BottomModalDefault(
+                      text: '수정하기',
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
                     ),
-                  ),
+                    BottomModalWithAlert(
+                      funcName: '삭제하기',
+                      title: '댓글을 삭제하시겠어요?',
+                      body: '삭제된 댓글은 복원할 수 없습니다.',
+                      func: () => postsProvider.deleteComment(
+                        postId: comment.postId, commentId: comment.id
+                      ).then((successful) {
+                        if (successful) {
+                          deleteFunc(comment.id);
+                          postsProvider.fetchPosts(postsProvider.boardId);
+                          Navigator.pop(context);
+                          Navigator.pop(context);
+                        }
+                      }),
+                    ),
+                  ] : [
+                    BottomModalDefault(
+                      text: '쪽지 보내기',
+                      onPressed: () => showMaterialModalBottomSheet(
+                        context: context,
+                        useRootNavigator: true,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.only(
+                            topLeft: Radius.circular(20),
+                            topRight: Radius.circular(20),
+                          ),
+                        ),
+                        builder: (context) => Container(
+                          child: SingleChildScrollView(
+                            child: BottomModalWithMessage(
+                              funcName: '보내기',
+                              title: '${comment.profile.nickname} 님에게 쪽지 보내기',
+                              profile: comment.profile,
+                              func: null,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    PostCommentReport(comment.profile),
+                    BottomModalWithAlert(
+                      funcName: '차단하기',
+                      title: '${comment.profile.nickname} 님을 차단하시겠어요?',
+                      body: '사용자를 차단하면, 해당 사용자의 게시글 및 댓글을 확인 할 수 없으며, 서로 쪽지를 주고 받을 수 없습니다.\n\n차단계정 관리는 프로필>계정 설정> 차단 목록 관리 탭에서 확인 가능합니다',
+                      func: () {},
+                    ),
+                  ],
                 ),
               ),
             ),
-            PostCommentReport(comment.profile),
-            BottomModalWithAlert(
-              funcName: '차단하기',
-              title: '${comment.profile.nickname} 님을 차단하시겠어요?',
-              body: '사용자를 차단하면, 해당 사용자의 게시글 및 댓글을 확인 할 수 없으며, 서로 쪽지를 주고 받을 수 없습니다.\n\n차단계정 관리는 프로필>계정 설정> 차단 목록 관리 탭에서 확인 가능합니다',
-              func: () {},
-            ),
-          ],
-        ),
+          );
+        }
       ),
     );
   }

--- a/lib/screens/boards/comments/comments.dart
+++ b/lib/screens/boards/comments/comments.dart
@@ -6,15 +6,16 @@ import 'comment_body.dart';
 class Comments extends StatelessWidget {
   final Comment comment;
   final bool isAuthor;
+  final Function deleteFunc;
 
-  Comments({this.comment, this.isAuthor});
+  Comments({this.comment, this.isAuthor, this.deleteFunc});
 
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        CommentBanner(comment, isAuthor),
+        CommentBanner(comment, isAuthor, deleteFunc),
         CommentBody(comment),
       ],
     );

--- a/lib/screens/boards/posts/detail/post_detail_more.dart
+++ b/lib/screens/boards/posts/detail/post_detail_more.dart
@@ -18,7 +18,7 @@ class PostDetailMore extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    _navigatePage(BuildContext context) async {
+    void _navigatePage(BuildContext context) async {
       final result = await Navigator.push(
         context,
         MaterialPageRoute(
@@ -30,6 +30,7 @@ class PostDetailMore extends StatelessWidget {
       );
       getEditedPost(result);
     }
+
     return SingleChildScrollView(
       child: Container(
         padding: EdgeInsets.only(left: 24, top: 24, bottom: 21),


### PR DESCRIPTION
> resolves #81 

### What I've Done
- 댓글 삭제 Task 완료!
  - Comment 인스턴스는 **PostDetail** 위젯에서 FutureBuilder를 정의하여 `snapshot.data`에 담긴 채 **Comment** 관련 하위 위젯들로 뿌려져 렌더링되고 있었음. 
  - 그러나 댓글 삭제 API는 Provider에 정의해두기 때문에, Provider에 담긴 List<Comment>는 삭제가 되어도 화면에 렌더링된 Comment 인스턴스는 남아 있는 버그가 생김. (~사실 버그는 아니고 당연한 현상이라 할 수 있지만...~)
  - 이를 해결하기 위해, `snapshot.data`를 관리하는 FutureBuilder 단에서 Comment 인스턴스를 삭제하는 함수(deleteComment)를 정의하여 하위 위젯으로 넘겨주는 방식을 택함.
  - 최종적으로는, 댓글 삭제 API가 수행되는 **CommentMore** 위젯에서 `DELETE posts/{postId}/comments/{commentId}` API 수행 성공 시, **PostDetail**로부터 내려온 deleteComment를 실행하여 해당 Comment 인스턴스를 삭제할 수 있었음.

<br>
