### PR TITLE
Fix / Silo 이슈 해결

### DIFF
--- a/lib/providers/posts/posts.dart
+++ b/lib/providers/posts/posts.dart
@@ -19,6 +19,7 @@ class Posts extends ChangeNotifier with Toast {
   List<Post> _newPosts;
   List<Comment> _comments;
   int _boardId = 0; // default : 피드게시판
+  int _createdPostId;
   bool loading = false;
 
   Posts(Authenticate authProvider) {
@@ -29,6 +30,7 @@ class Posts extends ChangeNotifier with Toast {
   Post get post => _post;
   bool get hasNext => _hasNext;
   int get boardId => _boardId;
+  int get createdPostId => _createdPostId;
   List<Post> get posts => _posts;
   List<Post> get newPosts => _newPosts;
   List<Comment> get comments => _comments;
@@ -128,6 +130,9 @@ class Posts extends ChangeNotifier with Toast {
           files: files,
         ).then((response) async {
           if (response.statusCode == 200) {
+            final jsonUtf8 = decodeKo(response);
+            final Map<String, dynamic> jsonData = json.decode(jsonUtf8);
+            _createdPostId = jsonData['postId'];
             successful = true;
             loading = false;
             showToast(success: true, msg: '게시글을 작성했습니다.');

--- a/lib/providers/posts/posts.dart
+++ b/lib/providers/posts/posts.dart
@@ -37,7 +37,6 @@ class Posts extends ChangeNotifier with Toast {
 
   Future fetchPosts(int boardId) async {
     loading = true;
-    print(await _authProvider.getFirebaseIdToken());
     try {
       await HttpRequest()
           .get(
@@ -75,7 +74,7 @@ class Posts extends ChangeNotifier with Toast {
     return _posts;
   }
 
-  /// For Pagination
+  /// For Pagination in BoardsFeed Widget using _loadMore()
   Future addPosts({int boardId, int beforePostId}) async {
     loading = true;
     try {

--- a/lib/screens/boards/boards_feed.dart
+++ b/lib/screens/boards/boards_feed.dart
@@ -77,6 +77,7 @@ class _BoardsFeedState extends State<BoardsFeed> {
     return _isFirstLoadRunning
         ? Center(child: guamProgressIndicator())
         : RefreshIndicator(
+            color: Color(0xF9F8FFF), // GuamColorFamily.purpleLight1
             onRefresh: () async => _firstLoad(),
             child: SingleChildScrollView(
               controller: _scrollController,

--- a/lib/screens/boards/boards_feed.dart
+++ b/lib/screens/boards/boards_feed.dart
@@ -77,7 +77,7 @@ class _BoardsFeedState extends State<BoardsFeed> {
     return _isFirstLoadRunning
         ? Center(child: guamProgressIndicator())
         : RefreshIndicator(
-            onRefresh: () => context.read<Posts>().fetchPosts(widget.boardId),
+            onRefresh: () async => _firstLoad(),
             child: SingleChildScrollView(
               controller: _scrollController,
               child: Column(

--- a/lib/screens/boards/posts/detail/post_detail.dart
+++ b/lib/screens/boards/posts/detail/post_detail.dart
@@ -144,6 +144,7 @@ class _PostDetailState extends State<PostDetail> with Toast {
           ),
         ),
         body: RefreshIndicator(
+          color: Color(0xF9F8FFF), // GuamColorFamily.purpleLight1
           onRefresh: () => context.read<Posts>().getPost(widget.post.id),
           child: SingleChildScrollView(
             physics: AlwaysScrollableScrollPhysics(),

--- a/lib/screens/boards/posts/detail/post_detail_body.dart
+++ b/lib/screens/boards/posts/detail/post_detail_body.dart
@@ -49,6 +49,7 @@ class PostDetailBody extends StatelessWidget {
         ),
         if (post.imagePaths.isNotEmpty)
           GridView.builder(
+            physics: NeverScrollableScrollPhysics(),
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: min(post.imagePaths.length, maxRenderImgCnt),
               crossAxisSpacing: 10,

--- a/lib/screens/boards/posts/detail/post_detail_body.dart
+++ b/lib/screens/boards/posts/detail/post_detail_body.dart
@@ -71,10 +71,6 @@ class PostDetailBody extends StatelessWidget {
                         pictures: [...this.post.imagePaths],
                         initialPage: idx,
                         showImageActions: true,
-                        // showImageActions: creatorId != null && context.read<Posts>().isMe(creatorId),
-                        // deleteFunc: threadId != null ? deleteThreadImage
-                        //     : commentId != null ? deleteCommentImage
-                        //     : null,
                       ),
                     )
                   )

--- a/lib/screens/messages/message_detail.dart
+++ b/lib/screens/messages/message_detail.dart
@@ -86,6 +86,7 @@ class _MessageDetailState extends State<MessageDetail> {
           ),
         ),
         body: RefreshIndicator(
+          color: Color(0xF9F8FFF), // GuamColorFamily.purpleLight1
           onRefresh: () => context.read<Messages>().getMessages(widget.otherProfile.id),
           child: SingleChildScrollView(
             physics: AlwaysScrollableScrollPhysics(),

--- a/lib/screens/notifications/notifications_body.dart
+++ b/lib/screens/notifications/notifications_body.dart
@@ -40,6 +40,7 @@ class _NotificationsBodyState extends State<NotificationsBody> {
       color: GuamColorFamily.grayscaleWhite,
       padding: EdgeInsets.only(top: 18),
       child: RefreshIndicator(
+        color: Color(0xF9F8FFF), // GuamColorFamily.purpleLight1
         onRefresh: () => context.read<Notifications>().fetchNotifications(),
         child: SingleChildScrollView(
           physics: AlwaysScrollableScrollPhysics(),


### PR DESCRIPTION
> resolves #53 resolves #69 

- [x] 게시글 생성 시 생성된 게시글로 이동
  > 舊) 게시글 생성 후 피드로 Navigator.pop() 하기만 했었음.

- [x] BoardsFeed 위젯에서의 refresh 함수 수정
  > Pagination 붙인 이후로는 위젯 내에서 `List<Post> _posts`로 게시글 리스트를 관리하기 때문에 단순히 `context.read<Posts>().fetchPosts(widget.boardId)`로는 최신 게시글 리로드가 안됨. 따라서 _firstLoad()를 Future로 감싸서 onRefresh CallBack 함수로 수정

- [x] 게시글 내 첨부 사진들이 사진을 감싸는 컨테이너 내에서 스크롤 되는 현상 수정

