### PR TITLE
Release/1.1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ app.*.symbols
 # Obfuscation related
 app.*.map.json
 
+# Android Signing
+android/key.properties

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,6 +6,13 @@ if (localPropertiesFile.exists()) {
     }
 }
 
+def keystoreProperties = new Properties()
+// keytool -list -v -keystore key.jks
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {
     throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
@@ -13,18 +20,12 @@ if (flutterRoot == null) {
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
-    flutterVersionCode = '13'
+    flutterVersionCode = '14'
 }
 
 def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
-    flutterVersionName = '13'
-}
-
-def keystoreProperties = new Properties()
-def keystorePropertiesFile = rootProject.file('key.properties')
-if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+    flutterVersionName = '14'
 }
 
 apply plugin: 'com.android.application'
@@ -49,10 +50,11 @@ android {
         versionName flutterVersionName
     }
 
+    // https://stackoverflow.com/questions/54457245/a-problem-occurred-evaluating-project-app-path-may-not-be-null-or-empty-st
+    // https://itwise.tistory.com/47
+    /// https://flutter-ko.dev/docs/deployment/android
     signingConfigs {
         release {
-            // https://stackoverflow.com/questions/54457245/a-problem-occurred-evaluating-project-app-path-may-not-be-null-or-empty-st
-            // https://itwise.tistory.com/47
             keyAlias keystoreProperties['keyAlias']
             keyPassword keystoreProperties['keyPassword']
             storeFile file(keystoreProperties['storeFile'])
@@ -63,13 +65,10 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
-
-            /// https://flutter-ko.dev/docs/deployment/android
             minifyEnabled true
+
             useProguard true
-
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-
         }
     }
 }

--- a/lib/commons/common_text_field.dart
+++ b/lib/commons/common_text_field.dart
@@ -6,9 +6,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:guam_community_client/commons/custom_divider.dart';
 import 'package:guam_community_client/styles/colors.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:provider/provider.dart';
 import '../helpers/pick_image.dart';
-import '../providers/messages/messages.dart';
 import 'common_img_nickname.dart';
 import 'image/image_thumbnail.dart';
 import 'button_size_circular_progress_indicator.dart';
@@ -54,7 +52,11 @@ class _CommonTextFieldState extends State<CommonTextField> {
 
   void setImageFile(PickedFile val) {
     setState(() {
-      if (val != null) imageFileList.add(val);
+      if (val != null) {
+        imageFileList.add(val);
+        /// 쪽지함의 경우, 사진을 한 장씩만 보내도록 FIFO 방식의 삭제 적용.
+        if (widget.messageTo != null && imageFileList.length > 1) imageFileList.removeAt(0);
+      }
     });
   }
 

--- a/lib/helpers/http_request.dart
+++ b/lib/helpers/http_request.dart
@@ -106,7 +106,7 @@ class HttpRequest with Toast {
 
       http.MultipartRequest request = http.MultipartRequest("PATCH", uri);
       request.headers['Authorization'] = 'Bearer $authToken';
-      fields.entries.forEach((e) => request.fields[e.key] = e.value);
+      fields.entries.forEach((e) => request.fields[e.key] = e.value ?? "");
 
       if (files != null)
         files.forEach((e) async {

--- a/lib/screens/boards/boards_feed.dart
+++ b/lib/screens/boards/boards_feed.dart
@@ -93,7 +93,7 @@ class _BoardsFeedState extends State<BoardsFeed> {
                         padding: EdgeInsets.only(top: 10, bottom: 40),
                         child: guamProgressIndicator(size: 40),
                       ),
-                    if (_hasNextPage == false)
+                    if (_hasNextPage == false && _posts.length > 10)
                       Container(
                         color: GuamColorFamily.purpleLight2,
                         padding: EdgeInsets.only(top: 10, bottom: 10),

--- a/lib/screens/messages/message_detail.dart
+++ b/lib/screens/messages/message_detail.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mentions/flutter_mentions.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:guam_community_client/commons/back.dart';
-import 'package:guam_community_client/commons/bottom_modal/bottom_modal_default.dart';
 import 'package:guam_community_client/commons/bottom_modal/bottom_modal_with_alert.dart';
 import 'package:guam_community_client/commons/common_text_field.dart';
 import 'package:guam_community_client/commons/custom_app_bar.dart';

--- a/lib/screens/messages/message_detail_body.dart
+++ b/lib/screens/messages/message_detail_body.dart
@@ -91,8 +91,7 @@ class MessageDetailBody extends StatelessWidget {
                     borderRadius: BorderRadius.circular(8),
                     image: DecorationImage(
                       fit: BoxFit.cover,
-                      image: NetworkImage(
-                          HttpRequest().s3BaseAuthority + message.imagePath),
+                      image: NetworkImage(HttpRequest().s3BaseAuthority + message.imagePath),
                     ),
                   ),
                 ),

--- a/lib/screens/messages/message_preview.dart
+++ b/lib/screens/messages/message_preview.dart
@@ -41,6 +41,9 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
   Widget build(BuildContext context) {
     Authenticate authProvider = context.read<Authenticate>();
     MessageBox msgBox = widget.messageBox;
+    /// 가장 최근 메시지가 읽혀지지 않았고, 해당 메시지 발신자가 나인 경우
+    bool newMsg = !msgBox.lastLetter.isRead
+        && msgBox.lastLetter.sentTo == authProvider.me.id;
 
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 16, vertical: 6),
@@ -98,8 +101,7 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
                       ),
                     ),
                     /// 가장 최근 메시지가 읽혀지지 않았고, 해당 메시지 발신자가 나인 경우
-                    if (!msgBox.lastLetter.isRead
-                        && msgBox.lastLetter.sentTo == authProvider.me.id)
+                    if (newMsg)
                       Positioned(
                         top: 0,
                         child: CircleAvatar(
@@ -133,9 +135,7 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
                             fontSize: 12,
                             height: 1.6,
                             fontFamily: GuamFontFamily.SpoqaHanSansNeoRegular,
-                            /// 가장 최근 메시지가 읽혀지지 않았고, 해당 메시지 발신자가 나인 경우
-                            color: !msgBox.lastLetter.isRead
-                                && msgBox.lastLetter.sentTo == authProvider.me.id
+                            color: newMsg
                                 ? GuamColorFamily.grayscaleGray2
                                 : GuamColorFamily.grayscaleGray4,
                           ),

--- a/lib/screens/messages/message_preview.dart
+++ b/lib/screens/messages/message_preview.dart
@@ -33,9 +33,14 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
     super.dispose();
   }
 
+  void asdf () async {
+    widget.onRefresh();
+  }
+
   @override
   Widget build(BuildContext context) {
     Authenticate authProvider = context.read<Authenticate>();
+    MessageBox msgBox = widget.messageBox;
 
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 16, vertical: 6),
@@ -56,10 +61,10 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
                     ChangeNotifierProvider(create: (_) => Messages(authProvider)),
                   ],
                   child: FutureBuilder(
-                    future: context.read<Messages>().getMessages(widget.messageBox.otherProfile.id),
+                    future: context.read<Messages>().getMessages(msgBox.otherProfile.id),
                     builder: (_, AsyncSnapshot<List<Message.Message>> snapshot) {
                       if (snapshot.hasData) {
-                        return MessageDetail(snapshot.data, widget.messageBox.otherProfile, widget.onRefresh);
+                        return MessageDetail(snapshot.data, msgBox.otherProfile, widget.onRefresh);
                       } else if (snapshot.hasError) {
                         Navigator.pop(context);
                         showToast(success: false, msg: '해당 쪽지를 찾을 수 없습니다.');
@@ -86,13 +91,15 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
                         shape: BoxShape.circle,
                         image: DecorationImage(
                           fit: BoxFit.cover,
-                          image: widget.messageBox.otherProfile.profileImg != null
-                              ? NetworkImage(HttpRequest().s3BaseAuthority + widget.messageBox.otherProfile.profileImg)
+                          image: msgBox.otherProfile.profileImg != null
+                              ? NetworkImage(HttpRequest().s3BaseAuthority + msgBox.otherProfile.profileImg)
                               : SvgProvider('assets/icons/profile_image.svg')
                         ),
                       ),
                     ),
-                    if (!widget.messageBox.lastLetter.isRead)
+                    /// 가장 최근 메시지가 읽혀지지 않았고, 해당 메시지 발신자가 나인 경우
+                    if (!msgBox.lastLetter.isRead
+                        && msgBox.lastLetter.sentTo == authProvider.me.id)
                       Positioned(
                         top: 0,
                         child: CircleAvatar(
@@ -110,7 +117,7 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
                         Text(
-                          widget.messageBox.otherProfile.nickname,
+                          msgBox.otherProfile.nickname,
                           style: TextStyle(
                             fontSize: 12,
                             height: 1.6,
@@ -119,16 +126,18 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
                           ),
                         ),
                         Text(
-                          widget.messageBox.lastLetter.text,
+                          msgBox.lastLetter.text,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: TextStyle(
                             fontSize: 12,
                             height: 1.6,
                             fontFamily: GuamFontFamily.SpoqaHanSansNeoRegular,
-                            color: widget.messageBox.lastLetter.isRead
-                                ? GuamColorFamily.grayscaleGray4
-                                : GuamColorFamily.grayscaleGray2,
+                            /// 가장 최근 메시지가 읽혀지지 않았고, 해당 메시지 발신자가 나인 경우
+                            color: !msgBox.lastLetter.isRead
+                                && msgBox.lastLetter.sentTo == authProvider.me.id
+                                ? GuamColorFamily.grayscaleGray2
+                                : GuamColorFamily.grayscaleGray4,
                           ),
                         ),
                       ],
@@ -158,7 +167,7 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
                             title: '쪽지함을 삭제하시겠어요?',
                             body: '삭제된 쪽지는 복원할 수 없습니다.',
                             func: () async => await context.read<Messages>()
-                                .deleteMessageBox(widget.messageBox.otherProfile.id)
+                                .deleteMessageBox(msgBox.otherProfile.id)
                                 .then((successful) async {
                                   context.read<Messages>().fetchMessageBoxes();
                                   if (successful) {
@@ -177,7 +186,7 @@ class _MessagePreviewState extends State<MessagePreview> with Toast {
                 Padding(
                   padding: EdgeInsets.only(right: 10, top: 14, bottom: 15),
                   child: Text(
-                    Jiffy(widget.messageBox.lastLetter.createdAt).fromNow(),
+                    Jiffy(msgBox.lastLetter.createdAt).fromNow(),
                     style: TextStyle(
                       fontSize: 12,
                       height: 1.6,

--- a/lib/screens/notifications/notifications_body.dart
+++ b/lib/screens/notifications/notifications_body.dart
@@ -106,7 +106,7 @@ class _NotificationsBodyState extends State<NotificationsBody> {
                     padding: EdgeInsets.only(top: 10, bottom: 40),
                     child: guamProgressIndicator(size: 40),
                   ),
-                if (_hasNextPage == false)
+                if (_hasNextPage == false && _currentPage > 2)
                   Container(
                     color: GuamColorFamily.purpleLight2,
                     padding: EdgeInsets.only(top: 10, bottom: 10),

--- a/lib/screens/profiles/pages/profiles_edit.dart
+++ b/lib/screens/profiles/pages/profiles_edit.dart
@@ -83,7 +83,7 @@ class _ProfilesEditState extends State<ProfilesEdit> with Toast {
 
   Future setProfile() async {
     toggleSending();
-    imgReset = profileImage.isEmpty;
+    imgReset = profileImage.isEmpty && profileImg == null;
     try {
       if (input['nickname'] == null || input['nickname'] == '') {
         return showToast(success: false, msg: '닉네임을 설정해주세요.');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.1.3
+version: 1.1.4
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
- [x] 게시판(알림) 내 일정 수준 이상의 게시글(알림)이 페이지네이션 되어야 "전체 게시글(알림)을 불러왔습니다" 문구를 띄우도록 수정.
  > `_hasNextPage == false && _posts.length > 10`

<br>

- [x] 새로운 쪽지가 왔음을 알려주는 boolean 로직 수정 (newMsg = )
  > `newMsg = !msgBox.lastLetter.isRead && msgBox.lastLetter.sentTo == authProvider.me.id;`

<br>

- [x] 쪽지에서는 한 번에 하나의 이미지만 보내도록 제한하는 클라 로직 추가 (FIFO)
```
 imageFileList.add(val);
 /// 쪽지함의 경우, 사진을 한 장씩만 보내도록 FIFO 방식의 삭제 적용.
 if (widget.messageTo != null && imageFileList.length > 1) imageFileList.removeAt(0);
```