### PR TITLE
Fix: Splash Screen Loop

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,7 +36,7 @@ class MyApp extends StatelessWidget {
     return FutureBuilder(
       future: Future.delayed(Duration(milliseconds: 1500)),
       builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting || authProvider.initialLoading) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
           return MaterialApp(
             initialRoute: '/',
             debugShowCheckedModeBanner: false,

--- a/lib/screens/app/splash/splash_screen.dart
+++ b/lib/screens/app/splash/splash_screen.dart
@@ -24,7 +24,7 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
     _animationController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 1500),
-    )..repeat();
+    )..forward();
   }
 
   @override

--- a/lib/screens/app/splash/splash_text.dart
+++ b/lib/screens/app/splash/splash_text.dart
@@ -21,7 +21,7 @@ class _SplashTextState extends State<SplashText> with SingleTickerProviderStateM
     _animationController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 1500),
-    )..repeat();
+    )..forward();
   }
 
   @override

--- a/lib/screens/user_auth/auth.dart
+++ b/lib/screens/user_auth/auth.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:guam_community_client/screens/app/splash/splash_screen.dart';
+import 'package:guam_community_client/screens/login/login_wallpaper.dart';
 import 'package:guam_community_client/screens/login/signup/signup.dart';
 import 'package:provider/provider.dart';
 import '../../providers/home/home_provider.dart';
@@ -11,7 +13,7 @@ class Auth extends StatelessWidget {
   Widget build(BuildContext context) {
     final authProvider = context.watch<Authenticate>();
 
-    return authProvider.userSignedIn()
+    return authProvider.initialLoading ? Scaffold(body: LoginWallpaper()) : authProvider.userSignedIn()
         ? authProvider.profileExists()
           ? ChangeNotifierProvider(
             create: (_) => HomeProvider(),


### PR DESCRIPTION
스플래쉬 화면 반복되는 현상 해결했습니다.
원인은 FutureBuilder가 Future.delayed(Duration(milliseconds: 1500)) 이후에는 listen을 하지 않아서인 것 같습니다(?). 
예를들어 getMyProfile()이 1.5초 이상 딜레이 될 경우 initialLoading = true인 상태에서 FutureBuilder의 future가 끝나기(ConnectionState.done이 되면 FutureBuilder는 계속 같은 위젯을 리턴하는 것으로 추정됩니다) 때문에 if (snapshot.connectionState == ConnectionState.waiting || initialLoading)에 걸린 채로  SplashScreen 이 지속되었던 것 같아요. 