### PR TITLE
Feature/ 계정 삭제

### DIFF
--- a/lib/providers/user_auth/authenticate.dart
+++ b/lib/providers/user_auth/authenticate.dart
@@ -144,8 +144,6 @@ class Authenticate extends ChangeNotifier with Toast {
           authToken: authToken,
         ).then((response) async {
           if (response.statusCode == 200) {
-            print(response.statusCode);
-            await getMyProfile();
             successful = true;
             showToast(success: true, msg: "계정을 삭제했습니다.");
 

--- a/lib/screens/profiles/pages/logout_modal.dart
+++ b/lib/screens/profiles/pages/logout_modal.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+import '../../../commons/custom_divider.dart';
+import '../../../styles/colors.dart';
+import '../../../styles/fonts.dart';
+
+class LogoutModal extends StatelessWidget {
+  final Function func;
+
+  LogoutModal({required this.func});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Container(
+        padding: EdgeInsets.only(left: 24, top: 24, right: 18, bottom: 14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '정말 로그아웃 하시겠어요?',
+                  style: TextStyle(fontSize: 18, color: GuamColorFamily.grayscaleGray2),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text(
+                    '돌아가기',
+                    style: TextStyle(fontSize: 16, color: GuamColorFamily.purpleCore,
+                    ),
+                  ),
+                  style: TextButton.styleFrom(
+                    padding: EdgeInsets.zero,
+                    minimumSize: Size(30, 26),
+                    alignment: Alignment.centerRight,
+                  ),
+                ),
+              ],
+            ),
+            CustomDivider(color: GuamColorFamily.grayscaleGray7),
+            Padding(
+              padding: EdgeInsets.symmetric(vertical: 20),
+              child: Text(
+                '다시 로그인할 사람 괌!',
+                style: TextStyle(fontSize: 14, height: 1.6, fontFamily: GuamFontFamily.SpoqaHanSansNeoRegular),
+              ),
+            ),
+            Center(
+              child: TextButton(
+                onPressed: () async {
+                  func();
+                  Navigator.pop(context);
+                },
+                child: Text(
+                  '로그아웃',
+                  style: TextStyle(fontSize: 16, color: GuamColorFamily.redCore),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/profiles/pages/settings.dart
+++ b/lib/screens/profiles/pages/settings.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:guam_community_client/commons/back.dart';
+import 'package:guam_community_client/screens/profiles/pages/logout_modal.dart';
+import 'package:guam_community_client/screens/profiles/pages/withdrawal_modal.dart';
 import 'package:guam_community_client/styles/colors.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:provider/provider.dart';
 import '../../../commons/custom_app_bar.dart';
-import '../../../commons/custom_divider.dart';
 import '../../../providers/user_auth/authenticate.dart';
-import '../../../styles/fonts.dart';
 import '../buttons/long_button.dart';
 import 'blacklist_edit.dart';
 
@@ -49,57 +49,29 @@ class Settings extends StatelessWidget {
                     providers: [
                       ChangeNotifierProvider(create: (_) => Authenticate()),
                     ],
-                    child: SingleChildScrollView(
-                      child: Container(
-                        padding: EdgeInsets.only(left: 24, top: 24, right: 18, bottom: 14),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Text(
-                                  '정말 로그아웃 하시겠어요?',
-                                  style: TextStyle(fontSize: 18, color: GuamColorFamily.grayscaleGray2),
-                                ),
-                                TextButton(
-                                  onPressed: () => Navigator.of(context).pop(),
-                                  child: Text(
-                                    '돌아가기',
-                                    style: TextStyle(fontSize: 16, color: GuamColorFamily.purpleCore,
-                                    ),
-                                  ),
-                                  style: TextButton.styleFrom(
-                                    padding: EdgeInsets.zero,
-                                    minimumSize: Size(30, 26),
-                                    alignment: Alignment.centerRight,
-                                  ),
-                                ),
-                              ],
-                            ),
-                            CustomDivider(color: GuamColorFamily.grayscaleGray7),
-                            Padding(
-                              padding: EdgeInsets.symmetric(vertical: 20),
-                              child: Text(
-                                '다시 로그인할 사람 괌!',
-                                style: TextStyle(fontSize: 14, height: 1.6, fontFamily: GuamFontFamily.SpoqaHanSansNeoRegular),
-                              ),
-                            ),
-                            Center(
-                              child: TextButton(
-                                onPressed: () async {
-                                  context.read<Authenticate>().signOut();
-                                  Navigator.pop(context);
-                                },
-                                child: Text(
-                                  '로그아웃',
-                                  style: TextStyle(fontSize: 16, color: GuamColorFamily.redCore),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
+                    child: LogoutModal(
+                      func: () => context.read<Authenticate>().signOut(),
+                    ),
+                  ),
+                ),
+              ),
+              LongButton(
+                label: '계정 삭제',
+                onPressed: () => showMaterialModalBottomSheet(
+                  context: context,
+                  useRootNavigator: true,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(20),
+                      topRight: Radius.circular(20),
+                    ),
+                  ),
+                  builder: (context) => MultiProvider(
+                    providers: [
+                      ChangeNotifierProvider(create: (_) => Authenticate()),
+                    ],
+                    child: WithdrawalModal(
+                      func: () => context.read<Authenticate>().deleteUser(),
                     ),
                   ),
                 ),

--- a/lib/screens/profiles/pages/withdrawal_modal.dart
+++ b/lib/screens/profiles/pages/withdrawal_modal.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+import '../../../commons/custom_divider.dart';
+import '../../../styles/colors.dart';
+import '../../../styles/fonts.dart';
+
+class WithdrawalModal extends StatelessWidget {
+  final Function func;
+
+  WithdrawalModal({required this.func});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Container(
+        padding: EdgeInsets.only(left: 24, top: 24, right: 18, bottom: 14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '정말 계정을 삭제하시겠어요?',
+                  style: TextStyle(fontSize: 18, color: GuamColorFamily.grayscaleGray2),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text(
+                    '돌아가기',
+                    style: TextStyle(fontSize: 16, color: GuamColorFamily.purpleCore,
+                    ),
+                  ),
+                  style: TextButton.styleFrom(
+                    padding: EdgeInsets.zero,
+                    minimumSize: Size(30, 26),
+                    alignment: Alignment.centerRight,
+                  ),
+                ),
+              ],
+            ),
+            CustomDivider(color: GuamColorFamily.grayscaleGray7),
+            Padding(
+              padding: EdgeInsets.symmetric(vertical: 20),
+              child: Text(
+                '계정 삭제 이후에는 작성한 게시글과 댓글을 수정/삭제할 수 없으며, 쪽지 기록이 초기화됩니다.',
+                style: TextStyle(fontSize: 14, height: 1.6, fontFamily: GuamFontFamily.SpoqaHanSansNeoRegular),
+              ),
+            ),
+            Center(
+              child: TextButton(
+                onPressed: () async {
+                  func();
+                  Navigator.pop(context);
+                },
+                child: Text(
+                  '계정 삭제',
+                  style: TextStyle(fontSize: 16, color: GuamColorFamily.redCore),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/user_auth/auth.dart
+++ b/lib/screens/user_auth/auth.dart
@@ -12,13 +12,15 @@ class Auth extends StatelessWidget {
   Widget build(BuildContext context) {
     final authProvider = context.watch<Authenticate>();
 
-    return authProvider.initialLoading ? Scaffold(body: LoginWallpaper()) : authProvider.userSignedIn()
-        ? authProvider.profileExists()
-          ? ChangeNotifierProvider(
-            create: (_) => HomeProvider(),
-            child: App(),
-          )
-          : SignUp()
-        : LoginPage();
+    return authProvider.initialLoading
+        ? Scaffold(body: LoginWallpaper())
+        : authProvider.userSignedIn()
+          ? authProvider.profileExists()
+            ? ChangeNotifierProvider(
+              create: (_) => HomeProvider(),
+              child: App(),
+            )
+            : SignUp()
+          : LoginPage();
   }
 }


### PR DESCRIPTION
- [x] 로그아웃 코드 리팩토링 (모달 부분 새 위젯으로 분리)

- [x] 계정 삭제 API 연동 및 버튼 구현

* @kwish2 소원님, `await auth.currentUser?.delete();`를 통해 auth.currentUser를 null로 만들고, 그에 따라 랜딩 페이지 선택 로직에 사용되는 `authProvider.userSignedIn()` 값을 true -> false로 변화시키게 됩니다. 다만, `authProvider.profileExists()`에도 영향을 미치는 것 같은데(앱 -> 닉네임 설정 -> 로그인 페이지로 2단계 이동하는걸 느끼실 수 있습니다.) 소원님도 그렇게 렌더링 되나요??